### PR TITLE
Supporting Dropwizard 0.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,15 +34,15 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>0.8.1</dropwizard.version>
-        <jetty.version>9.2.9.v20150224</jetty.version>
+        <dropwizard.version>0.9.1</dropwizard.version>
+        <jetty.version>9.2.13.v20150730</jetty.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>javax.websocket</groupId>
             <artifactId>javax.websocket-api</artifactId>
-            <version>1.0</version>
+            <version>1.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/be/tomcools/dropwizard/websocket/WebsocketBundle.java
+++ b/src/main/java/be/tomcools/dropwizard/websocket/WebsocketBundle.java
@@ -9,7 +9,7 @@ import io.dropwizard.setup.Environment;
 
 import javax.websocket.server.ServerEndpointConfig;
 
-public class WebsocketBundle implements ConfiguredBundle {
+public class WebsocketBundle<T extends Configuration> implements ConfiguredBundle<T> {
     private WebsocketHandlerFactory handlerFactory = new WebsocketHandlerFactory();
 
     private WebsocketHandler handler;
@@ -25,7 +25,7 @@ public class WebsocketBundle implements ConfiguredBundle {
         handler.addEndpoint(serverEndpointConfig);
     }
 
-    public void run(Configuration configuration, Environment environment) {
+    public void run(T configuration, Environment environment) {
         handler = handlerFactory.forEnvironment(environment);
         ServerFactory serverFactory = configuration.getServerFactory();
         ServerFactoryWrapper factoryWrapper = new ServerFactoryWrapper(serverFactory, handler);
@@ -35,10 +35,5 @@ public class WebsocketBundle implements ConfiguredBundle {
     @Override
     public void initialize(Bootstrap bootstrap) {
         //This method is not used because no initialization logic is required.
-    }
-
-    @Override
-    public void run(Object configuration, Environment environment) throws Exception {
-        run((Configuration) configuration, environment);
     }
 }

--- a/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/IntegrationTestApplication.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/IntegrationTestApplication.java
@@ -3,28 +3,42 @@ package be.tomcools.dropwizard.websocket.integrationtest;
 import be.tomcools.dropwizard.websocket.WebsocketBundle;
 import be.tomcools.dropwizard.websocket.integrationtest.annotatedjavaee.PingPongServerEndpoint;
 import be.tomcools.dropwizard.websocket.integrationtest.programmaticjavaee.ProgrammaticServerEndpoint;
+import com.codahale.metrics.health.HealthCheck;
 import io.dropwizard.Application;
+import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 import javax.websocket.server.ServerEndpointConfig;
+import java.util.concurrent.CountDownLatch;
 
-public class IntegrationTestApplication extends Application<IntegrationTestConfiguration> {
+public class IntegrationTestApplication extends Application<Configuration> {
     private WebsocketBundle websocket = new WebsocketBundle();
+    CountDownLatch initLatch = new CountDownLatch(1);
 
     @Override
-    public void initialize(Bootstrap<IntegrationTestConfiguration> bootstrap) {
+    public void initialize(Bootstrap<Configuration> bootstrap) {
         super.initialize(bootstrap);
         bootstrap.addBundle(websocket);
     }
 
     @Override
-    public void run(IntegrationTestConfiguration configuration, Environment environment) throws Exception {
+    public void run(Configuration configuration, Environment environment) throws Exception {
         //Annotated endpoint
         websocket.addEndpoint(PingPongServerEndpoint.class);
 
         //programmatic endpoint
         ServerEndpointConfig serverEndpointConfig = ServerEndpointConfig.Builder.create(ProgrammaticServerEndpoint.class, "/programmatic").build();
         websocket.addEndpoint(serverEndpointConfig);
+
+        // healthcheck to keep output quiet
+        environment.healthChecks().register("healthy", new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return Result.healthy();
+            }
+        });
+
+        initLatch.countDown();
     }
 }

--- a/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/IntegrationTestConfiguration.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/IntegrationTestConfiguration.java
@@ -1,6 +1,0 @@
-package be.tomcools.dropwizard.websocket.integrationtest;
-
-import io.dropwizard.Configuration;
-
-public class IntegrationTestConfiguration extends Configuration {
-}

--- a/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/WebsocketBundleIT.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/WebsocketBundleIT.java
@@ -10,6 +10,7 @@ import javax.websocket.Session;
 import javax.websocket.WebSocketContainer;
 import java.io.IOException;
 import java.net.URI;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -18,10 +19,12 @@ public class WebsocketBundleIT {
     Thread server;
     @Before
     public void init() throws InterruptedException {
+        final IntegrationTestApplication integrationTestApplication = new IntegrationTestApplication();
+
         server = new Thread(new Runnable() {
             public void run() {
                 try {
-                    new IntegrationTestApplication().run("server");
+                    integrationTestApplication.run("server");
                 } catch (Exception e) {
                     throw new IllegalStateException(e);
                 }
@@ -29,7 +32,7 @@ public class WebsocketBundleIT {
         });
         server.run();
 
-        Thread.sleep(7000);
+        integrationTestApplication.initLatch.await(7000, TimeUnit.SECONDS);
     }
 
     @Test


### PR DESCRIPTION
- Bumped version of Dropwizard to 0.9.1
- Bumped version of Jetty to 9.2.13.v20150730 (to match Dropwizard)
- Bumped javax.websocket-api to 1.1
- Fixed use of generics in WebsocketBundle
- Sped up integration test by relying on countdownlatch instead of sleep
