### PR TITLE
Updated to work with DW 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>1.0.0</dropwizard.version>
-        <jetty.version>9.3.9.v20160517</jetty.version>
+        <dropwizard.version>2.1.1</dropwizard.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
     </properties>
 
     <dependencies>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.4</version>
+            <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
 
@@ -70,6 +70,14 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Mockito -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/be/tomcools/dropwizard/websocket/handling/WebsocketContainerInitializer.java
+++ b/src/main/java/be/tomcools/dropwizard/websocket/handling/WebsocketContainerInitializer.java
@@ -9,7 +9,7 @@ public class WebsocketContainerInitializer {
     public WebsocketContainer initialize(WebsocketConfiguration configuration,
                                          MutableServletContextHandler contextHandler) {
         try {
-            return new WebsocketContainer(configuration, WebSocketServerContainerInitializer.configureContext(contextHandler));
+            return new WebsocketContainer(configuration, WebSocketServerContainerInitializer.initialize(contextHandler));
         } catch (Exception e) {
             throw new IllegalStateException("Could not initialize contexthandler to enable Websockets", e);
         }

--- a/src/test/java/be/tomcools/dropwizard/websocket/WebsocketBundleTest.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/WebsocketBundleTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.websocket.server.ServerEndpointConfig;
 

--- a/src/test/java/be/tomcools/dropwizard/websocket/WebsocketHandlerFactoryTest.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/WebsocketHandlerFactoryTest.java
@@ -4,7 +4,7 @@ import io.dropwizard.setup.Environment;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/be/tomcools/dropwizard/websocket/WebsocketHandlerTest.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/WebsocketHandlerTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.websocket.*;
 import javax.websocket.server.ServerEndpoint;

--- a/src/test/java/be/tomcools/dropwizard/websocket/handling/ServerFactoryWrapperTest.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/handling/ServerFactoryWrapperTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/be/tomcools/dropwizard/websocket/handling/WebsocketContainerInitializerTest.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/handling/WebsocketContainerInitializerTest.java
@@ -3,23 +3,23 @@ package be.tomcools.dropwizard.websocket.handling;
 import be.tomcools.dropwizard.websocket.WebsocketConfiguration;
 import io.dropwizard.jetty.MutableServletContextHandler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler.Context;
 import org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import javax.servlet.ServletException;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class WebsocketContainerInitializerTest {
-
+    
     private MutableServletContextHandler servletContextHandler = mock(MutableServletContextHandler.class);
+    private Context servletContext = mock(Context.class);
     private WebsocketConfiguration configuration = new WebsocketConfiguration();
     private Server server = mock(Server.class, RETURNS_DEEP_STUBS);
 
@@ -32,6 +32,7 @@ public class WebsocketContainerInitializerTest {
     @Before
     public void init() {
         servletContextHandler.setAttribute(WebSocketUpgradeFilter.class.getName(), upgradeFilter);
+        when(servletContextHandler.getServletContext()).thenReturn(servletContext);
         when(servletContextHandler.getServer()).thenReturn(server);
     }
 
@@ -44,9 +45,8 @@ public class WebsocketContainerInitializerTest {
 
     @Test(expected = IllegalStateException.class)
     public void whenSomethingGoesWrongDuringInitializeThrowsIllegalStateException() {
-        when(servletContextHandler.getServer()).thenThrow(ServletException.class);
-        WebsocketContainer container = sut.initialize(configuration, servletContextHandler);
-
-        assertNotNull(container);
+        when(servletContextHandler.getServer()).thenThrow(RuntimeException.class);
+    
+        sut.initialize(configuration, servletContextHandler);
     }
 }

--- a/src/test/java/be/tomcools/dropwizard/websocket/handling/WebsocketContainerTest.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/handling/WebsocketContainerTest.java
@@ -7,12 +7,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.websocket.DeploymentException;
 import javax.websocket.server.ServerContainer;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)


### PR DESCRIPTION
The readme in the main branch states that the legacy version is compatible with DW 2.x, but this isn't correct due to the older version of jetty that is being used.

Even though this version of the project is stated as non-maintained it would be good to have a release that is compatible with a current non-beta DW release whilst waiting for DW 4 to leave beta.