### PR TITLE
Introduce support of Dropwizard 3.0.8 and JEE7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>be.tomcools</groupId>
-    <artifactId>dropwizard-websocket-jsr356-bundle</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <artifactId>dropwizard-websocket-jee7-bundle</artifactId>
+    <version>3.0.8</version>
     <packaging>jar</packaging>
 
-    <name>dropwizard-websocket-jsr356-bundle</name>
+    <name>dropwizard-websocket-jee7-bundle</name>
     <description>Dropwizard bundle to enable the use of Java Websockets.</description>
     <url>https://github.com/TomCools/dropwizard-websocket-jee7-bundle</url>
     <licenses>
@@ -28,13 +28,14 @@
         <url>https://github.com/TomCools/dropwizard-websocket-jee7-bundle</url>
         <connection>scm:git:https://github.com/TomCools/dropwizard-websocket-jee7-bundle.git</connection>
         <developerConnection>scm:git:https://github.com/TomCools/dropwizard-websocket-jee7-bundle.git</developerConnection>
-        <tag>dropwizard-websocket-jsr356-bundle-0.0.104</tag>
+        <tag>dropwizard-websocket-jee7-bundle-0.0.104</tag>
     </scm>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>4.0.0</dropwizard.version>
+        <dropwizard.version>3.0.8</dropwizard.version>
+        <jetty.version>9.4.56.v20240826</jetty.version>
         <java.version>11</java.version>
     </properties>
 
@@ -52,9 +53,15 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.websocket</groupId>
+            <artifactId>javax.websocket-api</artifactId>
+            <version>1.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.26</version>
+            <version>1.18.34</version>
             <scope>provided</scope>
         </dependency>
 
@@ -79,7 +86,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>4.8.1</version>
+            <version>5.13.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -98,7 +105,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.14.1</version>
+            <version>3.16.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -106,13 +113,23 @@
         <!-- Jetty -->
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-jakarta-server</artifactId>
+            <artifactId>javax-websocket-server-impl</artifactId>
+            <version>${jetty.version}</version>
         </dependency>
+        <!--<dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-jakarta-server</artifactId>
+        </dependency>-->
         <!-- To run javax.websocket client -->
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-jakarta-client</artifactId>
+            <artifactId>javax-websocket-client-impl</artifactId>
+            <version>${jetty.version}</version>
         </dependency>
+        <!--<dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-jakarta-client</artifactId>
+        </dependency>-->
     </dependencies>
 
     <distributionManagement>
@@ -131,12 +148,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -145,21 +162,21 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.10.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-sources-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.1</version>
             </plugin>
             <plugin>
                 <groupId>org.jreleaser</groupId>
                 <artifactId>jreleaser-maven-plugin</artifactId>
-                <version>1.5.1</version>
+                <version>1.14.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.5.0</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/be/tomcools/dropwizard/websocket/WebsocketBundle.java
+++ b/src/main/java/be/tomcools/dropwizard/websocket/WebsocketBundle.java
@@ -5,7 +5,7 @@ import io.dropwizard.core.Configuration;
 import io.dropwizard.core.ConfiguredBundle;
 import io.dropwizard.core.server.ServerFactory;
 import io.dropwizard.core.setup.Environment;
-import jakarta.websocket.server.ServerEndpointConfig;
+import javax.websocket.server.ServerEndpointConfig;;
 
 public class WebsocketBundle<T extends Configuration> implements ConfiguredBundle<T> {
     private final WebsocketHandlerFactory handlerFactory = new WebsocketHandlerFactory();

--- a/src/main/java/be/tomcools/dropwizard/websocket/WebsocketHandler.java
+++ b/src/main/java/be/tomcools/dropwizard/websocket/WebsocketHandler.java
@@ -4,13 +4,14 @@ import be.tomcools.dropwizard.websocket.handling.WebsocketContainer;
 import be.tomcools.dropwizard.websocket.handling.WebsocketContainerInitializer;
 import be.tomcools.dropwizard.websocket.registration.EndpointRegistration;
 import io.dropwizard.core.setup.Environment;
-import jakarta.servlet.ServletContext;
-import jakarta.websocket.DeploymentException;
-import jakarta.websocket.server.ServerContainer;
-import jakarta.websocket.server.ServerEndpointConfig;
-import org.eclipse.jetty.websocket.jakarta.server.config.JakartaWebSocketServletContainerInitializer;
+import org.eclipse.jetty.websocket.jsr356.server.ServerContainer;
+import org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer;
 
-public class WebsocketHandler implements JakartaWebSocketServletContainerInitializer.Configurator {
+import javax.servlet.ServletContext;
+import javax.websocket.DeploymentException;
+import javax.websocket.server.ServerEndpointConfig;
+
+public class WebsocketHandler implements WebSocketServerContainerInitializer.Configurator {
     private final EndpointRegistration endpointRegistration;
     private final WebsocketConfiguration configuration;
     private final Environment environment;
@@ -35,15 +36,13 @@ public class WebsocketHandler implements JakartaWebSocketServletContainerInitial
         this.endpointRegistration.add(serverEndpointConfig);
     }
 
-    public void initialize() {        
+    public void initialize() {
         containerInitializer.initialize(environment.getApplicationContext(), this);
     }
 
     @Override
-    public void accept(ServletContext servletContext, ServerContainer serverContainer) {
+    public void accept(ServletContext servletContext, ServerContainer serverContainer) throws DeploymentException {
         WebsocketContainer container = new WebsocketContainer(configuration, serverContainer);
         container.registerEndpoints(endpointRegistration.getRegisteredEndpoints());
     }
-
-
 }

--- a/src/main/java/be/tomcools/dropwizard/websocket/handling/WebsocketContainer.java
+++ b/src/main/java/be/tomcools/dropwizard/websocket/handling/WebsocketContainer.java
@@ -4,10 +4,10 @@ import be.tomcools.dropwizard.websocket.WebsocketConfiguration;
 import be.tomcools.dropwizard.websocket.registration.Endpoint;
 import be.tomcools.dropwizard.websocket.registration.Endpoints;
 import be.tomcools.dropwizard.websocket.registration.endpointtypes.EndpointProgrammaticJava;
-import jakarta.websocket.DeploymentException;
-import jakarta.websocket.server.ServerContainer;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.websocket.DeploymentException;
+import javax.websocket.server.ServerContainer;
 import java.util.Optional;
 
 @Slf4j
@@ -32,28 +32,28 @@ public class WebsocketContainer {
     }
 
     public void registerEndpoints(final Endpoints endpoints) {
-        final Endpoints succesfullyAdded = new Endpoints();
+        final Endpoints successfullyAdded = new Endpoints();
 
         for (Endpoint endpoint : endpoints) {
             try {
                 register(endpoint);
-                succesfullyAdded.add(endpoint);
+                successfullyAdded.add(endpoint);
             } catch (DeploymentException e) {
                 log.error("Could not add websocket endpoint {} to the deployment.", endpoint, e);
             }
         }
-        logRegisteredEndpoints(succesfullyAdded);
+        logRegisteredEndpoints(successfullyAdded);
     }
 
-    private void logRegisteredEndpoints(Endpoints succesfullyAdded) {
+    private void logRegisteredEndpoints(Endpoints successfullyAdded) {
         StringBuilder endpointsAdded = new StringBuilder("Registered websocket endpoints: ")
                 .append(System.lineSeparator())
                 .append(System.lineSeparator());
 
-        if (succesfullyAdded.isEmpty()) {
+        if (successfullyAdded.isEmpty()) {
             endpointsAdded.append("\tNONE \tNo endpoints were added to the server. Check logs for errors if you registered endpoints.").append(System.lineSeparator());
         } else {
-            for (Endpoint endpoint : succesfullyAdded) {
+            for (Endpoint endpoint : successfullyAdded) {
                 String endpointLogString = String.format("\tGET\t\t%s (%s)", endpoint.getPath(), endpoint.getEndpointClass().getName());
                 endpointsAdded.append(endpointLogString).append(System.lineSeparator());
             }

--- a/src/main/java/be/tomcools/dropwizard/websocket/handling/WebsocketContainerInitializer.java
+++ b/src/main/java/be/tomcools/dropwizard/websocket/handling/WebsocketContainerInitializer.java
@@ -1,14 +1,13 @@
 package be.tomcools.dropwizard.websocket.handling;
 
-
 import io.dropwizard.jetty.MutableServletContextHandler;
-import org.eclipse.jetty.websocket.jakarta.server.config.JakartaWebSocketServletContainerInitializer;
+import org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer;
 
 public class WebsocketContainerInitializer {
     public void initialize(MutableServletContextHandler contextHandler,
-                           JakartaWebSocketServletContainerInitializer.Configurator configurator) {
+                           WebSocketServerContainerInitializer.Configurator configurator) {
         try {
-            JakartaWebSocketServletContainerInitializer.configure(contextHandler, configurator);
+            WebSocketServerContainerInitializer.configure(contextHandler, configurator);
         } catch (Exception e) {
             throw new IllegalStateException("Could not initialize context handler to enable Websockets", e);
         }

--- a/src/main/java/be/tomcools/dropwizard/websocket/registration/EndpointRegistration.java
+++ b/src/main/java/be/tomcools/dropwizard/websocket/registration/EndpointRegistration.java
@@ -2,9 +2,9 @@ package be.tomcools.dropwizard.websocket.registration;
 
 import be.tomcools.dropwizard.websocket.registration.endpointtypes.EndpointAnnotatedJava;
 import be.tomcools.dropwizard.websocket.registration.endpointtypes.EndpointProgrammaticJava;
-import jakarta.websocket.server.ServerEndpoint;
-import jakarta.websocket.server.ServerEndpointConfig;
 
+import javax.websocket.server.ServerEndpoint;
+import javax.websocket.server.ServerEndpointConfig;
 import java.util.Optional;
 
 public class EndpointRegistration {

--- a/src/main/java/be/tomcools/dropwizard/websocket/registration/endpointtypes/EndpointProgrammaticJava.java
+++ b/src/main/java/be/tomcools/dropwizard/websocket/registration/endpointtypes/EndpointProgrammaticJava.java
@@ -1,7 +1,8 @@
 package be.tomcools.dropwizard.websocket.registration.endpointtypes;
 
 import be.tomcools.dropwizard.websocket.registration.Endpoint;
-import jakarta.websocket.server.ServerEndpointConfig;
+
+import javax.websocket.server.ServerEndpointConfig;
 
 public class EndpointProgrammaticJava extends Endpoint {
     private final ServerEndpointConfig config;

--- a/src/test/java/be/tomcools/dropwizard/websocket/WebsocketHandlerFactoryTest.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/WebsocketHandlerFactoryTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(MockitoExtension.class)
 public class WebsocketHandlerFactoryTest {
     private final Environment environment = mock(Environment.class, RETURNS_DEEP_STUBS);
-    private WebsocketConfiguration configuration = mock(WebsocketConfiguration.class);
+    private final WebsocketConfiguration configuration = mock(WebsocketConfiguration.class);
 
 
     @InjectMocks

--- a/src/test/java/be/tomcools/dropwizard/websocket/WebsocketHandlerTest.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/WebsocketHandlerTest.java
@@ -5,15 +5,16 @@ import be.tomcools.dropwizard.websocket.registration.EndpointRegistration;
 import be.tomcools.dropwizard.websocket.registration.Endpoints;
 import io.dropwizard.core.Configuration;
 import io.dropwizard.core.setup.Environment;
-import jakarta.websocket.*;
-import jakarta.websocket.server.ServerEndpoint;
-import jakarta.websocket.server.ServerEndpointConfig;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.websocket.*;
+import javax.websocket.server.ServerEndpoint;
+import javax.websocket.server.ServerEndpointConfig;
 
 import static org.mockito.Mockito.*;
 
@@ -73,7 +74,7 @@ public class WebsocketHandlerTest {
     }
 
     @ServerEndpoint("/chat")
-    class TestEndpoint {
+    static class TestEndpoint {
         @OnOpen
         public void open(Session session) {
         }

--- a/src/test/java/be/tomcools/dropwizard/websocket/handling/WebsocketContainerTest.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/handling/WebsocketContainerTest.java
@@ -3,14 +3,15 @@ package be.tomcools.dropwizard.websocket.handling;
 import be.tomcools.dropwizard.websocket.WebsocketConfiguration;
 import be.tomcools.dropwizard.websocket.registration.Endpoints;
 import be.tomcools.dropwizard.websocket.registration.endpointtypes.EndpointAnnotatedJava;
-import jakarta.websocket.DeploymentException;
-import jakarta.websocket.server.ServerContainer;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.websocket.DeploymentException;
+import javax.websocket.server.ServerContainer;
 
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/IntegrationConfiguration.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/IntegrationConfiguration.java
@@ -4,8 +4,9 @@ import be.tomcools.dropwizard.websocket.WebsocketBundleConfiguration;
 import be.tomcools.dropwizard.websocket.WebsocketConfiguration;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.core.Configuration;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 public class IntegrationConfiguration extends Configuration implements WebsocketBundleConfiguration {
 

--- a/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/IntegrationTestApplication.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/IntegrationTestApplication.java
@@ -7,10 +7,11 @@ import com.codahale.metrics.health.HealthCheck;
 import io.dropwizard.core.Application;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.core.setup.Environment;
-import jakarta.websocket.server.ServerEndpointConfig;
+
+import javax.websocket.server.ServerEndpointConfig;
 
 public class IntegrationTestApplication extends Application<IntegrationConfiguration> {
-    private WebsocketBundle websocket = new WebsocketBundle();
+    private final WebsocketBundle websocket = new WebsocketBundle();
 
     @Override
     public void initialize(Bootstrap<IntegrationConfiguration> bootstrap) {

--- a/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/annotatedjavaee/PingPongClientEndpoint.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/annotatedjavaee/PingPongClientEndpoint.java
@@ -1,8 +1,8 @@
 package be.tomcools.dropwizard.websocket.integrationtest.annotatedjavaee;
 
-import jakarta.websocket.*;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.websocket.*;
 import java.io.IOException;
 import java.net.URI;
 
@@ -33,7 +33,7 @@ public class PingPongClientEndpoint {
 
     @OnMessage
     public void processMessage(String message) {
-       log.info("Client: Received message: " + message);
+        log.info("Client: Received message: {}", message);
         if(handler != null) {
             handler.handleMessage(message);
         }

--- a/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/annotatedjavaee/PingPongServerEndpoint.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/annotatedjavaee/PingPongServerEndpoint.java
@@ -1,9 +1,9 @@
 package be.tomcools.dropwizard.websocket.integrationtest.annotatedjavaee;
 
-import jakarta.websocket.*;
-import jakarta.websocket.server.ServerEndpoint;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.websocket.*;
+import javax.websocket.server.ServerEndpoint;
 import java.io.IOException;
 
 

--- a/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/programmaticjavaee/ProgrammaticServerEndpoint.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/integrationtest/programmaticjavaee/ProgrammaticServerEndpoint.java
@@ -1,11 +1,9 @@
 package be.tomcools.dropwizard.websocket.integrationtest.programmaticjavaee;
 
-
-import jakarta.websocket.Endpoint;
-import jakarta.websocket.EndpointConfig;
-import jakarta.websocket.MessageHandler;
-import jakarta.websocket.Session;
-
+import javax.websocket.Endpoint;
+import javax.websocket.EndpointConfig;
+import javax.websocket.MessageHandler;
+import javax.websocket.Session;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/src/test/java/be/tomcools/dropwizard/websocket/registration/EndpointRegistrationTest.java
+++ b/src/test/java/be/tomcools/dropwizard/websocket/registration/EndpointRegistrationTest.java
@@ -2,12 +2,13 @@ package be.tomcools.dropwizard.websocket.registration;
 
 import be.tomcools.dropwizard.websocket.registration.endpointtypes.EndpointProgrammaticJava;
 import be.tomcools.dropwizard.websocket.registration.endpointtypes.EndpointType;
-import jakarta.websocket.Endpoint;
-import jakarta.websocket.*;
-import jakarta.websocket.server.ServerEndpoint;
-import jakarta.websocket.server.ServerEndpointConfig;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;;
+import org.junit.jupiter.api.Test;
+
+import javax.websocket.Endpoint;
+import javax.websocket.*;
+import javax.websocket.server.ServerEndpoint;
+import javax.websocket.server.ServerEndpointConfig;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -15,7 +16,7 @@ import static org.hamcrest.core.Is.is;
 
 public class EndpointRegistrationTest {
 
-    private EndpointRegistration registration = new EndpointRegistration();
+    private final EndpointRegistration registration = new EndpointRegistration();
 
     @Test
     public void canAddAndReturnRegisteredEndpoints() {
@@ -69,7 +70,7 @@ public class EndpointRegistrationTest {
     }
 
     @ServerEndpoint("/chat")
-    class AnnotatedEndpoint {
+    static class AnnotatedEndpoint {
         @OnOpen
         public void open(Session session) {
         }
@@ -87,7 +88,7 @@ public class EndpointRegistrationTest {
         }
     }
 
-    class ProgrammaticEndpoint extends Endpoint {
+    static class ProgrammaticEndpoint extends Endpoint {
         @Override
         public void onOpen(Session session, EndpointConfig endpointConfig) {
             //To change body of implemented methods use File | Settings | File Templates.


### PR DESCRIPTION
Hi there,

due to high complexity with migration between dropwizard versons  2.1.x  and 4.x I'd like to introduce intermediate step - support dropwizard 3.0.x and also would like to uses JEE instead of Jakarta.

I've checked naming strategy for package and decided to name artifact `dropwizard-websocket-jee7-bundle`.
I'm looking forward for any suggestion regarding merging this feature branch